### PR TITLE
Initial update

### DIFF
--- a/Get SNC Alternative.sql
+++ b/Get SNC Alternative.sql
@@ -1,0 +1,88 @@
+ SELECT county 
+  ,facn 
+  ,facnam 
+  ,major 
+  ,station 
+  ,reporting_code 
+  ,parameter_name 
+  ,MAX(percent_exceedance) as Max_Percent_Exceed
+  ,SUM(decode(sign(percent_exceedance-decode(paratype,1,40,20)),1,1,0)) as Months_Big_Vios
+  ,COUNT(*) as Months_Vios
+  ,DECODE(SUBSTR(facn,1,1),'0','Southeast','1','Southwest','2','Northwest','3','Northeast','4','Central') as District
+ 
+ FROM
+     ( 
+   SELECT cc.county_name county, 
+       SUBSTR(p.ohio_epa_no,1,8) facn, 
+       cp.core_place_name facnam, fr.major major, 
+       to_number(substr(e.event_comments,2,3)) station, 
+       substr(e.event_comments,23,5) reporting_code, 
+       SUBSTR(e.event_comments,28,23) parameter_name, 
+       to_char(e.event_sched_start_date, 'FMMonth yyyy') viomonth, 
+       ROUND(max(ABS(substr(e.event_comments,68,7)-substr(e.event_comments,61,7))/substr(e.event_comments,61,7)),3)*100 percent_exceedance, 
+       g.no_of_samples paratype 
+  
+  FROM swims.event e 
+    INNER JOIN swims.event_permit ep      ON e.event_id = ep.event_id 
+    INNER JOIN swims.permit p             ON ep.permit_id = p.permit_id 
+    INNER JOIN coreadmin.core_place cp    ON p.core_place_id = cp.core_place_id 
+    INNER JOIN coreadmin.core_facility cf ON cp.core_place_id = cf.core_place_id 
+    INNER JOIN coreadmin.cmtb_county cc   ON cf.fips_county_code = cc.fips_county_code 
+    INNER JOIN swims.mor_preprint_base g  ON g.rep_code = substr(e.event_comments,23,5) 
+    
+    LEFT OUTER JOIN  
+       (    SELECT core_place_id, 
+                    'M' major 
+             FROM swims.facility_relationship 
+             WHERE fac_type_id = 3693 
+        ) fr 
+       ON p.core_place_id = fr.core_place_id 
+  
+  WHERE p.permit_type_id in (153,154) 
+    AND e.event_type_id = 6535 
+    AND e.expire_flag is null 
+    AND e.event_sched_start_date >= TO_DATE('01-Feb-2020','dd-mon-yyyy') 
+    AND e.event_sched_start_date < TO_DATE('01-Aug-2020','dd-mon-yyyy') 
+  --     AND e.event_sched_start_date >= TO_DATE('" & Format(datQueryStart, "dd-mmm-yyyy") & "','dd-mon-yyyy') 
+  --     AND e.event_sched_start_date < TO_DATE('" & Format(datQueryEnd, "dd-mmm-yyyy") & "','dd-mon-yyyy') 
+  --      and cc.county_name in (" & strCounty & ") 
+  --     AND p.ohio_epa_no like '" & UCase(Left(strOhioNo, 8)) & "%' 
+    AND trim(substr(e.event_comments,61,7)) is not null 
+    AND trim(substr(e.event_comments,68,7)) is not null 
+    AND trim(substr(e.event_comments,68,7)) <> '.' 
+    AND substr(trim(substr(e.event_comments,68,7)),1,1) <> '#' 
+    AND to_number(trim(substr(e.event_comments,61,7))) > 0 
+    AND g.no_of_samples in (1,2,3)
+    AND g.form_status_flag = 'P' 
+    AND (ABS(substr(e.event_comments,68,7)-substr(e.event_comments,61,7))/substr(e.event_comments,61,7)) > .01 
+    AND SUBSTR(p.ohio_epa_no,1,1) <> '9' 
+  GROUP BY cc.county_name, 
+    SUBSTR(p.ohio_epa_no,1,8), 
+    cp.core_place_name, fr.major, 
+    to_number(substr(e.event_comments,2,3)), 
+    substr(e.event_comments,23,5), 
+    SUBSTR(e.event_comments,28,23), 
+    to_char(e.event_sched_start_date, 'FMMonth yyyy'), 
+    g.no_of_samples
+  )    
+WHERE NOT (facn='0IB00026' and station=2  )
+  OR NOT (facn='0IB00027' and station=1  ) 
+  OR NOT (facn='2IE00000' and station=99 ) 
+  OR NOT (facn='2IG00007' and reporting_code='00015' and station = 602 ) 
+  OR NOT (facn='2IG00007' and reporting_code='00680' and station = 2 ) 
+  OR NOT (facn='3IF00017' and reporting_code='00530' and station = 2 ) 
+  OR NOT (facn='3IY00081' and reporting_code='00400' and station = 1) 
+
+GROUP BY county 
+  ,facn
+  ,facnam
+  ,major 
+  ,station 
+  ,reporting_code 
+  ,parameter_name
+  ,DECODE(SUBSTR(facn,1,1),'0','Southeast','1','Southwest','2','Northeast','3','Northwest','4','Central') 
+
+HAVING count(*) >= 4 
+  OR SUM(decode(sign(percent_exceedance-decode(paratype,1,40,20)),1,1,0)) >= 2 
+
+Order By county, facn, parameter_name 

--- a/Missing_DMRs.sql
+++ b/Missing_DMRs.sql
@@ -1,86 +1,53 @@
-SELECT COUNT(rq.DMR_period) - COUNT(rc.DATE_RECEIVED)
-FROM
-  (SELECT pm.ohio_epa_no,
-    pr.us_epa_no,
-    pr.core_place_name,
-    pm.dmr_period,
-    SUBSTR(pr.ohio_epa_no,1,8) facn,
-    pr.station_code
-  FROM
-    (SELECT d.dmr_period,
-      p.ohio_epa_no,
-      p.permit_id
-    FROM
-      ( SELECT DISTINCT begin_date dmr_period
-      FROM swims.measurement_header
-      WHERE begin_date >= '01-JAN-20' 
-      AND end_date <  '01-JAN-21' 
-      ) d,
-      swims.permit p
-    WHERE p.effective_date <= d.dmr_period
-    AND p.OHIO_EPA_NO LIKE '3IH00074%'
-    AND p.permit_status IN ('ACTIVE','EXPIRED')
-    AND p.effective_date =
-      (SELECT MAX(effective_date)
-      FROM swims.permit p2
-      WHERE SUBSTR(p2.ohio_epa_no,1,8) = SUBSTR(p.ohio_epa_no,1,8)
-      AND p2.permit_status            IN ('ACTIVE','EXPIRED')
-      AND p2.effective_date           <= d.dmr_period
-      )
-    ) pm,
-    ( SELECT DISTINCT p3.ohio_epa_no,
-      p3.us_epa_no,
-      cp.core_place_name,
-      s.station_code,
-      l.limit_type,
-      l.begin_date,
-      l.end_date,
-      se.month
-    FROM swims.permit p3,
-      swims.sampling_monitor_pt s,
-      --coreadmin.core_place_place cpp,
-      swims.sampling_station_limits sl,
-      swims.limits l,
-      swims.season se,
-      coreadmin.core_place cp
-    WHERE p3.permit_id           = s.permit_id
-    AND p3.core_place_id         = cp.core_place_id
-    --AND s.core_place_id          = cpp.core_place_place_id2
-    --AND cpp.core_place_place_id1 = sl.core_place_id
-    AND s.core_place_id = sl.core_place_id
-    AND sl.limit_id      = l.limit_id
-    AND l.season_type_id = se.season_type_id
-    AND p3.OHIO_EPA_NO LIKE '3IH00074%'
-    AND p3.permit_status         IN ('ACTIVE','EXPIRED')
-    AND p3.effective_date         < '01-JAN-21' --end date
-    AND l.measuring_frequency_id <>
-      (SELECT measuring_frequency_id
-      FROM swims.measuring_frequency
-      WHERE frequency_name = 'When Disch.'
-      )
-    ) pr
-  WHERE pm.ohio_epa_no = pr.ohio_epa_no
-  AND ((pm.dmr_period BETWEEN pr.begin_date AND pr.end_date)
-  OR (pr.limit_type                          = 93
-  AND pm.dmr_period                         >= pr.begin_date))
-  AND to_number(TO_CHAR(pm.dmr_period,'MM')) = pr.month
-  ORDER BY pm.dmr_period,
-    pr.station_code,
-    pr.month
-  ) rq,
-  (SELECT SUBSTR(mh.ohio_epa_no,1,8) facn,
-    mh.station_code,
-    mh.begin_date dmr_period,
-    mh.date_received
-  FROM swims.measurement_header mh,
-    swims.signature_block sb,
-    swims.notes nt
-  WHERE mh.srh_id = sb.link_id (+)
-  AND mh.srh_id   =nt.link_id(+)
-  AND mh.OHIO_EPA_NO LIKE '3IH00074%'
-  AND mh.begin_date >= '01-JAN-20'
-  AND mh.end_date    < '01-JAN-21'
-  ) rc
-WHERE rq.facn       = rc.facn (+)
-AND rq.station_code = rc.station_code (+)
-AND rq.dmr_period   = rc.dmr_period;
+SELECT 
+ substr(p.ohio_epa_No, 1, 8) as permit_no
+ , COUNT(DISTINCT dmr_period) as n_distinct_missing_months
+ , COUNT(dmr_period) as n_missing_dmrs
+
+FROM swims.permit p
+ INNER JOIN swims.sampling_monitor_pt s ON p.permit_id = s.permit_id
+ CROSS JOIN 
+  ( --create all months of the period
+    SELECT add_months('01-JAN-2020', level-1 ) dmr_period
+    FROM dual
+    CONNECT BY LEVEL <= 12
+  )
+
+WHERE p.ohio_epa_no LIKE '3IH00074%'
+ AND p.permit_status IN ('ACTIVE', 'EXPIRED') --ignore draft permits.
+ AND p.effective_date <= dmr_period -- permit needs to be effective
+ AND p.permit_id =
+  ( --correlated subquery; 
+    --give me the most recent permit version that was in effect prior to the DMR period
+   SELECT max(p2.permit_id)
+   FROM swims.permit p2 
+   WHERE substr(p2.ohio_epa_no,1,8) = substr(p.ohio_epa_no,1,8) 
+    AND p2.permit_status in ('ACTIVE','EXPIRED') 
+    AND p2.effective_date <= dmr_period 
+  )
+ AND NOT EXISTS
+  ( --Did they submit something? If so, no need to worry!
+    SELECT null
+    FROM swims.measurement_header mh
+    WHERE mh.begin_date = dmr_period
+     AND mh.core_Place_Id = s.core_Place_Id
+   )
+ AND EXISTS
+  (
+    -- Were they required to submit?
+    SELECT null
+    FROM swims.sampling_station_limits sl 
+    INNER JOIN swims.limits l                    ON sl.limit_id = l.limit_id 
+    INNER JOIN swims.season se                   ON l.season_type_id = se.season_type_id 
+
+   WHERE s.core_place_id = sl.core_place_id 
+    AND ((dmr_period between l.begin_date and l.end_date)  --dmr period must be between limit begin and end date
+    OR (l.limit_type = 93 and dmr_period >= l.begin_date)) --unless we have an administratively continued permit
+    AND EXTRACT (month FROM dmr_period) = se.month 
+    AND l.measuring_frequency_id <> 
+      (
+        SELECT measuring_frequency_id 
+         FROM swims.measuring_frequency 
+        WHERE frequency_name = 'When Disch.' --compliance excludes "WHEN DISCH" parameters
+       ) 
+  ) 
+GROUP BY substr(p.ohio_epa_No, 1, 8);


### PR DESCRIPTION
Hopefully simplifies everything. 

## Missing DMRs

The refactoring allows us to translate into plain English:

For a permit, give me the permit stations and months where

1. The permit was effective;
2. No DMR was submitted; and
3. DMR was required.

## Limit Violations

Updated to include

1. Out of the box returns
    + Code Vios
    + Freq Vios
    + Numeric Vios
    + Distinct months of numeric vios
    + Compliance schedule overdue
2. Table aliases

One thing I'll point out is that _BETWEEN_ is inclusive. It probably would not have made any real differences hear, but for some SQL that may include an extra month.

## Numeric SNC

This is the initial file I have. The translation is that for any parameter that has any exceedance for 4 out of 6 months makes the facility in SNC. The other way is 2 months out of 6 months of exceedances of 20% or 40% depending on the parameter.